### PR TITLE
Navigation localization

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,35 +1,63 @@
-- title: Start
+- title:
+    de: Start
+    en: Start
   url: "/"
   side: left
 
-- title: Downloads
+- title:
+    en: Downloads
+    de: Downloads
   url: "/downloads/"
   side: left
   dropdown:
-  - title: "Presskit"
+  - title:
+      en: "Presskit"
+      de: "Pressekit"
     url: "/downloads/presskit/"
 
-- title: "Templates"
+- title:
+    de: "Templates"
+    en: "English Templates"
   url: "/design/"
   side: left
   dropdown:
-  - title: "Grid & Colors"
+  - title:
+      de: "Kästchen & Farben"
+      en: "Grid & Colors"
     url: "/design/grid/"
-  - title: "Typography"
+  - title:
+      de: "Typography"
+      en: "Typography"
     url: "/design/typography/"
-  - title: "Page/Post"
+  - title:
+      de: "Page/Post"
+      en: "Page/Post"
     url: "/design/page/"
-  - title: "Post-Left-Sidebar"
+  - title:
+      de: "Post-Left-Sidebar"
+      en: "Post-Left-Sidebar"
     url: "/design/post-left-sidebar/"
-  - title: "Post-Right-Sidebar"
+  - title:
+      de: "Post-Right-Sidebar"
+      en: "Post-Right-Sidebar"
     url: "/design/post-right-sidebar/"
-  - title: "Page Full-Width"
+  - title:
+      de: "Page Full-Width"
+      en: "Page Full-Width"
     url: "/design/page-fullwidth/"
-  - title: "Blog-Page"
+  - title:
+      de: "Blog-Page"
+      en: "Blog-Page"
     url: "/blog/"
-  - title: "Video"
+  - title:
+      de: "Video"
+      en: "Video"
     url: "/design/video/"
-  - title: "Gallery"
+  - title:
+      de: "Gallery"
+      en: "Gallery"
     url: "/design/gallery/"
-  - title: "Portfolio"
+  - title:
+      de: "Portfolio"
+      en: "Portfolio"
     url: "/design/portfolio/"

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -35,14 +35,14 @@
             {% comment %}   If right side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
               <li class="divider"></li>
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language}}/{% endunless %}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title[page.language] }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language }}/{% endunless %}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title[page.language] }}</a></li>
 
             {% comment %}   If right side WITH dropdown menu do   {% endcomment %}
             {% else %}
 
               <li class="divider"></li>
               <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
-                <a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language}}/{% endunless %}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title[page.language] }}</a>
+                <a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language }}/{% endunless %}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title[page.language] }}</a>
 
                   <ul class="dropdown">
                     {% for dropdown_link in link.dropdown %}
@@ -53,7 +53,7 @@
                         {% assign domain = site.url %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language}}/{% endunless %}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title[page.language] }}</a></li>
+                      <li><a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language }}/{% endunless %}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title[page.language] }}</a></li>
                     {% endfor %}
                   </ul>
                   
@@ -89,14 +89,14 @@
 
             {% comment %}   If left side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language}}/{% endunless %}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title[page.language] }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language }}/{% endunless %}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title[page.language] }}</a></li>
               <li class="divider"></li>
 
             {% comment %}   If left side WITH dropdown menu do   {% endcomment %}
             {% else %}
 
               <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
-                <a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language}}/{% endunless %}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title[page.language] }}</a>
+                <a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language }}/{% endunless %}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title[page.language] }}</a>
 
                   <ul class="dropdown">
                     {% for dropdown_link in link.dropdown %}
@@ -107,7 +107,7 @@
                         {% assign domain = site.url %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language}}/{% endunless %}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title[page.language] }}</a></li>
+                      <li><a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language }}/{% endunless %}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title[page.language] }}</a></li>
                     {% endfor %}
                   </ul>
                   

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -35,14 +35,14 @@
             {% comment %}   If right side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
               <li class="divider"></li>
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language}}/{% endunless %}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title[page.language] }}</a></li>
 
             {% comment %}   If right side WITH dropdown menu do   {% endcomment %}
             {% else %}
 
               <li class="divider"></li>
               <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
-                <a href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title }}</a>
+                <a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language}}/{% endunless %}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title[page.language] }}</a>
 
                   <ul class="dropdown">
                     {% for dropdown_link in link.dropdown %}
@@ -53,7 +53,7 @@
                         {% assign domain = site.url %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title }}</a></li>
+                      <li><a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language}}/{% endunless %}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title[page.language] }}</a></li>
                     {% endfor %}
                   </ul>
                   
@@ -89,14 +89,14 @@
 
             {% comment %}   If left side WITHOUT dropdown menu do   {% endcomment %}
             {% if link.dropdown == nil %}
-              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title }}</a></li>
+              <li{% if link.url == page.url %} class="active"{% endif %}><a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language}}/{% endunless %}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title[page.language] }}</a></li>
               <li class="divider"></li>
 
             {% comment %}   If left side WITH dropdown menu do   {% endcomment %}
             {% else %}
 
               <li class="has-dropdown{% if link.url == page.url %} active{% endif %}">
-                <a href="{{ domain }}{{ site.baseurl }}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title }}</a>
+                <a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language}}/{% endunless %}{{ link.url }}"{% if link.url contains 'http' %} target="_blank"{% endif %}>{{ link.title[page.language] }}</a>
 
                   <ul class="dropdown">
                     {% for dropdown_link in link.dropdown %}
@@ -107,7 +107,7 @@
                         {% assign domain = site.url %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title }}</a></li>
+                      <li><a href="{{ domain }}{{ site.baseurl }}{% unless page.is_default_language %}{{ page.language}}/{% endunless %}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title[page.language] }}</a></li>
                     {% endfor %}
                   </ul>
                   


### PR DESCRIPTION
I think this works. Feels rather clunky, but...

There might be a bug hidden which I couldn't test locally: When your browser's language is English, and you switch to German (i.e., access `/de/`), "Start" will probably point to `/`, and thus switch you back to English.

A fix would be overriding the "Start"-URL in the template somehow (hackish), or adding explicitly localized URLs in `navigation.yml` (not elegant).
